### PR TITLE
stocks make sense :revolving_hearts:

### DIFF
--- a/utils/preprocessing.ipynb
+++ b/utils/preprocessing.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -62,7 +62,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_14478/2784137331.py:6: DtypeWarning: Columns (64) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_35031/2784137331.py:6: DtypeWarning: Columns (64) have mixed types. Specify dtype option on import or set low_memory=False.\n",
       "  merged_og = pd.read_csv(os.path.abspath(parent_path + '/data/merged.csv'))\n"
      ]
     }
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -135,31 +135,31 @@
      "output_type": "stream",
      "text": [
       "Countries without population data (pre drop): 25\n",
-      "Niue\n",
-      "Svalbard and Jan Mayen\n",
-      "Cook Islands\n",
-      "Saint Pierre and Miquelon\n",
-      "British Indian Ocean Territory\n",
-      "Wallis and Futuna\n",
-      "Anguilla\n",
-      "Tokelau\n",
-      "Falkland Islands (Malvinas)\n",
-      "Guadeloupe\n",
-      "Bouvet Island\n",
-      "Saint Helena, Ascension and Tristan da Cunha\n",
-      "Heard Island and McDonald Islands\n",
-      "French Guiana\n",
-      "Jersey\n",
-      "Martinique\n",
-      "Norfolk Island\n",
-      "Antarctica\n",
-      "Pitcairn\n",
-      "Réunion\n",
-      "Christmas Island\n",
-      "Montserrat\n",
       "Guernsey\n",
-      "Holy See (Vatican City State)\n",
+      "Jersey\n",
+      "Bouvet Island\n",
+      "Anguilla\n",
+      "Niue\n",
       "Mayotte\n",
+      "British Indian Ocean Territory\n",
+      "Montserrat\n",
+      "Saint Pierre and Miquelon\n",
+      "Holy See (Vatican City State)\n",
+      "Saint Helena, Ascension and Tristan da Cunha\n",
+      "Cook Islands\n",
+      "Norfolk Island\n",
+      "French Guiana\n",
+      "Pitcairn\n",
+      "Antarctica\n",
+      "Christmas Island\n",
+      "Guadeloupe\n",
+      "Réunion\n",
+      "Falkland Islands (Malvinas)\n",
+      "Tokelau\n",
+      "Martinique\n",
+      "Svalbard and Jan Mayen\n",
+      "Wallis and Futuna\n",
+      "Heard Island and McDonald Islands\n",
       "___________________________________________________________\n",
       "Countries without population data (post drop): 4\n",
       "Jersey\n",
@@ -176,7 +176,6 @@
     "print('Countries without population data (pre drop):', len(missing_pop_data))\n",
     "for isoc in missing_pop_data:\n",
     "    print(pc.countries.get(alpha_3=isoc).name)\n",
-    "\n",
     "\n",
     "# Drop rarely mentioned countries (with with <413 Month Entries in GDELT)\n",
     "# exception: 'SSD'\n",
@@ -195,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -243,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -392,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -546,7 +545,7 @@
        "[3 rows x 66 columns]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -561,7 +560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -575,7 +574,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_14478/1161258014.py:3: SettingWithCopyWarning: \n",
+      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_35031/1161258014.py:3: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
@@ -593,7 +592,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -653,7 +652,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -696,14 +695,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_14478/3429706013.py:8: SettingWithCopyWarning: \n",
+      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_35031/3429706013.py:8: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
@@ -775,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -824,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,7 +832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -850,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -980,7 +979,7 @@
        "[267 rows x 4 columns]"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1024,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1046,7 +1045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1198,7 +1197,7 @@
        "[9345 rows x 5 columns]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1216,7 +1215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1228,7 +1227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1614,7 +1613,7 @@
        "[413 rows x 73 columns]"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1625,14 +1624,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_14478/865657044.py:13: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
+      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_35031/865657044.py:13: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
       "To preserve the previous behavior, use\n",
       "\n",
       "\t>>> .groupby(..., group_keys=False)\n",
@@ -1670,7 +1669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1905,7 +1904,7 @@
        "76160 2021-07-01  4.009946e+07"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1917,7 +1916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1938,7 +1937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1957,7 +1956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -2108,7 +2107,7 @@
        "[281 rows x 5 columns]"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2138,7 +2137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2147,7 +2146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2158,7 +2157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2176,7 +2175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2192,7 +2191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -2494,7 +2493,7 @@
        "[281 rows x 14 columns]"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2509,7 +2508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -2542,7 +2541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -2551,7 +2550,7 @@
        "0"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2572,7 +2571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [
     {
@@ -2610,7 +2609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2626,7 +2625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2646,7 +2645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 148,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2658,7 +2657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [
     {
@@ -2861,7 +2860,7 @@
        "[281 rows x 9 columns]"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 149,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2869,6 +2868,365 @@
    "source": [
     "country_df = df_past[df_past['Country Name'] == 'Afghanistan']\n",
     "country_df[['Country Name', 'month_year', deaths_choice, 'past6', 'past12', 'past60', 'past120', conflict_choice, f'{conflict_choice}_since']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stock_simple(x: pd.Series, decay: float = 0.8):\n",
+    "    # xs is a stock of x inflow with a decay of 0.8\n",
+    "    # nans = x.isnull()\n",
+    "    x = list(x.fillna(0))\n",
+    "    xs = [] \n",
+    "    for n in range(len(x)):\n",
+    "        if n == 0: \n",
+    "            xs.append(x[n]) # stock starts in initial value\n",
+    "        else:\n",
+    "            xs.append(x[n] + decay * xs[n-1])\n",
+    "    \n",
+    "    return xs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 151,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_past[deaths_choice].isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 152,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(55309, 80)\n",
+      "(55309, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#event share stocks\n",
+    "decay = 0.8\n",
+    "\n",
+    "unit_of_analyis = 'isocode'\n",
+    "\n",
+    "print(df_past.shape)\n",
+    "\n",
+    "\n",
+    "lcols_novs = (df_past.groupby(unit_of_analyis)\n",
+    "         .apply(lambda x: stock_simple(x[deaths_choice], decay=decay))\n",
+    "         .explode().reset_index(drop=True)\n",
+    "         .rename(f'deaths_stock') for t in range(1,2))\n",
+    "\n",
+    "\n",
+    "temp_df = pd.DataFrame(lcols_novs).transpose()\n",
+    "\n",
+    "print(temp_df.shape)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 153,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_past.sort_values(by=['isocode', 'month_year'], inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>deaths_stock</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.276314</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.998341</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.418726</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4.641909</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4.132075</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55304</th>\n",
+       "      <td>0.000030</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55305</th>\n",
+       "      <td>0.000024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55306</th>\n",
+       "      <td>0.000019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55307</th>\n",
+       "      <td>0.000015</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55308</th>\n",
+       "      <td>0.000012</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>55309 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       deaths_stock\n",
+       "0          0.276314\n",
+       "1          0.998341\n",
+       "2          2.418726\n",
+       "3          4.641909\n",
+       "4          4.132075\n",
+       "...             ...\n",
+       "55304      0.000030\n",
+       "55305      0.000024\n",
+       "55306      0.000019\n",
+       "55307      0.000015\n",
+       "55308      0.000012\n",
+       "\n",
+       "[55309 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 154,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "temp_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 155,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(55309, 81)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "46333"
+      ]
+     },
+     "execution_count": 155,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_past.reset_index(drop=True, inplace=True)\n",
+    "df_past = df_past.join(temp_df)\n",
+    "\n",
+    "print(df_past.shape)\n",
+    "\n",
+    "df_past.isna().sum().sum()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 157,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>month_year</th>\n",
+       "      <th>deaths_all_intp_pop_pc</th>\n",
+       "      <th>deaths_stock</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2000-01-01</td>\n",
+       "      <td>0.276314</td>\n",
+       "      <td>0.276314</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2000-02-01</td>\n",
+       "      <td>0.777290</td>\n",
+       "      <td>0.998341</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2000-03-01</td>\n",
+       "      <td>1.620053</td>\n",
+       "      <td>2.418726</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2000-04-01</td>\n",
+       "      <td>2.706927</td>\n",
+       "      <td>4.641909</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2000-05-01</td>\n",
+       "      <td>0.418548</td>\n",
+       "      <td>4.132075</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>276</th>\n",
+       "      <td>2023-01-01</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2.565252</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>277</th>\n",
+       "      <td>2023-02-01</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2.052201</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>278</th>\n",
+       "      <td>2023-03-01</td>\n",
+       "      <td>0.124690</td>\n",
+       "      <td>1.766451</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>279</th>\n",
+       "      <td>2023-04-01</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.413161</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>280</th>\n",
+       "      <td>2023-05-01</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.130529</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>281 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    month_year  deaths_all_intp_pop_pc  deaths_stock\n",
+       "0   2000-01-01                0.276314      0.276314\n",
+       "1   2000-02-01                0.777290      0.998341\n",
+       "2   2000-03-01                1.620053      2.418726\n",
+       "3   2000-04-01                2.706927      4.641909\n",
+       "4   2000-05-01                0.418548      4.132075\n",
+       "..         ...                     ...           ...\n",
+       "276 2023-01-01                0.000000      2.565252\n",
+       "277 2023-02-01                0.000000      2.052201\n",
+       "278 2023-03-01                0.124690      1.766451\n",
+       "279 2023-04-01                0.000000      1.413161\n",
+       "280 2023-05-01                0.000000      1.130529\n",
+       "\n",
+       "[281 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 157,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_past.loc[df_past['isocode'] =='AFG', ['month_year', deaths_choice, 'deaths_stock']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 158,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_past.sort_values(by=['month_year', 'isocode'], inplace=True)"
    ]
   },
   {
@@ -2884,7 +3242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2894,7 +3252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 226,
    "metadata": {},
    "outputs": [
     {
@@ -2910,7 +3268,7 @@
        "46333"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 226,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2929,7 +3287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 227,
    "metadata": {},
    "outputs": [
     {
@@ -2937,9 +3295,7 @@
      "output_type": "stream",
      "text": [
       "min total events: 2.0\n",
-      "min total events gov: 0.0\n",
-      "min total events opp: 0.0\n",
-      "missing values in shares to be filled: 169773\n"
+      "missing values in shares to be filled: 46333\n"
      ]
     },
     {
@@ -2948,7 +3304,7 @@
        "0"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 227,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2956,28 +3312,28 @@
    "source": [
     "# List of all event count columns for gov, opp and total events\n",
     "event_cols = ['count_events_{}'.format(i) for i in range(1, 21)]\n",
-    "event_cols_gov = ['count_events_{}_gov'.format(i) for i in range(1, 21)]\n",
-    "event_cols_opp = ['count_events_{}_opp'.format(i) for i in range(1, 21)]\n",
+    "#event_cols_gov = ['count_events_{}_gov'.format(i) for i in range(1, 21)]\n",
+    "#event_cols_opp = ['count_events_{}_opp'.format(i) for i in range(1, 21)]\n",
     "\n",
     "# Compute the total events for each group\n",
     "df_shares['total_events'] = df_shares[event_cols].sum(axis=1)\n",
-    "df_shares['total_events_gov'] = df_shares[event_cols_gov].sum(axis=1)\n",
-    "df_shares['total_events_opp'] = df_shares[event_cols_opp].sum(axis=1)\n",
+    "#df_shares['total_events_gov'] = df_shares[event_cols_gov].sum(axis=1)\n",
+    "#df_shares['total_events_opp'] = df_shares[event_cols_opp].sum(axis=1)\n",
     "\n",
     "# Check if will be diving by zero\n",
     "print('min total events:', df_shares['total_events'].min())\n",
-    "print('min total events gov:', df_shares['total_events_gov'].min())\n",
-    "print('min total events opp:', df_shares['total_events_opp'].min())\n",
+    "#print('min total events gov:', df_shares['total_events_gov'].min())\n",
+    "#print('min total events opp:', df_shares['total_events_opp'].min())\n",
     "\n",
     "# Compute the share of each type of event for each group and create new columns\n",
     "for col in event_cols:\n",
     "    df_shares['share_events_{}'.format(col)] = df_shares[col] / df_shares['total_events'] *100\n",
     "    \n",
-    "for col in event_cols_gov:\n",
-    "    df_shares['share_events_{}'.format(col)] = df_shares[col] / df_shares['total_events_gov'] *100\n",
+    "# for col in event_cols_gov:\n",
+    "#     df_shares['share_events_{}'.format(col)] = df_shares[col] / df_shares['total_events_gov'] *100\n",
     "\n",
-    "for col in event_cols_opp:\n",
-    "    df_shares['share_events_{}'.format(col)] = df_shares[col] / df_shares['total_events_opp'] *100\n",
+    "# for col in event_cols_opp:\n",
+    "#     df_shares['share_events_{}'.format(col)] = df_shares[col] / df_shares['total_events_opp'] *100\n",
     "\n",
     "# Fill missing values with 0\n",
     "print('missing values in shares to be filled:', df_shares.isnull().sum().sum())\n",
@@ -2988,23 +3344,86 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 228,
    "metadata": {},
    "outputs": [],
    "source": [
     "for i in range(0, 21):\n",
     "    old_column_name = 'share_events_count_events_{}'.format(i)\n",
     "    new_column_name = 'share_events_{}'.format(i)\n",
-    "    old_column_name_gov = 'share_events_count_events_{}_gov'.format(i)\n",
-    "    new_column_name_gov = 'share_events_{}_gov'.format(i)\n",
-    "    old_column_name_opp = 'share_events_count_events_{}_opp'.format(i)\n",
-    "    new_column_name_opp = 'share_events_{}_opp'.format(i)\n",
-    "    df_shares.rename(columns={old_column_name: new_column_name, old_column_name_gov: new_column_name_gov, old_column_name_opp: new_column_name_opp}, inplace=True)\n"
+    "    # old_column_name_gov = 'share_events_count_events_{}_gov'.format(i)\n",
+    "    # new_column_name_gov = 'share_events_{}_gov'.format(i)\n",
+    "    # old_column_name_opp = 'share_events_count_events_{}_opp'.format(i)\n",
+    "    # new_column_name_opp = 'share_events_{}_opp'.format(i)\n",
+    "    df_shares.rename(columns={old_column_name: new_column_name}, inplace=True) # , old_column_name_gov: new_column_name_gov, old_column_name_opp: new_column_name_opp\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "INSTEAD of geenrating shares for each _gov and _opp event, we just capture what percentage of events in that month involve _gov and _opp as an actor."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 229,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 229,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#specific_events = ['state_deaths', 'nonstate_deaths', 'onesided_deaths', 'civilian_deaths']\n",
+    "\n",
+    "event_cols_gov = ['count_events_{}_gov'.format(i) for i in range(1, 21)]\n",
+    "event_cols_opp = ['count_events_{}_opp'.format(i) for i in range(1, 21)]\n",
+    "\n",
+    "df_shares['events_gov'] = df_shares[event_cols_gov].sum(axis=1)\n",
+    "df_shares['events_opp'] = df_shares[event_cols_opp].sum(axis=1)\n",
+    "\n",
+    "specific_events = ['events_gov', 'events_opp']\n",
+    "\n",
+    "# Compute the share of each subset of events of the total events - only when not dividing by zero\n",
+    "for col in specific_events:\n",
+    "    df_shares['share_{}'.format(col)] = np.where((df_shares['total_events'] > 0) & (df_shares[col] > 0),\n",
+    "                                                 round(df_shares[col] / df_shares['total_events'] * 100, 2), 0)\n",
+    "\n",
+    "# Drop the original columns\n",
+    "df_shares.drop(columns=specific_events, inplace=True)\n",
+    "\n",
+    "df_shares.isnull().sum().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 231,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.0 100.0 0.0 50.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df_shares.share_events_gov.min(), df_shares.share_events_gov.max(), df_shares.share_events_opp.min(), df_shares.share_events_opp.max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
    "metadata": {},
    "outputs": [
     {
@@ -3030,7 +3449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 164,
    "metadata": {},
    "outputs": [
     {
@@ -3057,14 +3476,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 165,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Manually normalised total events 72811    0.008301\n",
+      "Manually normalised total events 241    0.008301\n",
       "Name: total_events, dtype: float64\n",
       "Normalised total events from dataframe:\n"
      ]
@@ -3072,11 +3491,11 @@
     {
      "data": {
       "text/plain": [
-       "72811    0.008301\n",
+       "241    0.008301\n",
        "Name: norm_total_events, dtype: float64"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 165,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3096,7 +3515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3115,16 +3534,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 175,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(55309, 81)"
+       "(55309, 82)"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 175,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3137,50 +3556,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 176,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def stock_simple(x: pd.Series, decay: float = 0.8):\n",
-    "    # xs is a stock of x inflow with a decay of 0.8\n",
-    "    # nans = x.isnull()\n",
-    "    x = list(x.fillna(0))\n",
-    "    xs = [] \n",
-    "    for n in range(len(x)):\n",
-    "        if n == 0: \n",
-    "            xs.append(x[n]) # stock starts in initial value\n",
-    "        else:\n",
-    "            xs.append(x[n] + decay * xs[n-1])\n",
-    "    #list(np.where(nans, np.nan, xs))\n",
-    "    return xs\n",
+    "# def stock_simple(x: pd.Series, decay: float = 0.8):\n",
+    "#     # xs is a stock of x inflow with a decay of 0.8\n",
+    "#     # nans = x.isnull()\n",
+    "#     x = list(x.fillna(0))\n",
+    "#     xs = [] \n",
+    "#     for n in range(len(x)):\n",
+    "#         if n == 0: \n",
+    "#             xs.append(x[n]) # stock starts in initial value\n",
+    "#         else:\n",
+    "#             xs.append(x[n] + decay * xs[n-1])\n",
+    "#     #list(np.where(nans, np.nan, xs))\n",
+    "#     return xs\n",
     "\n",
-    "def stock_weighted(x: pd.Series, w: pd.Series, decay:float = 0.8):\n",
-    "    # xs is a stock of x inflow, weighted by w, with a decay of 0.8\n",
-    "    x = list(x.fillna(0))\n",
-    "    ws = stock_simple(w) # below this is the number of tokens for that country-month, which the stock_simple function turns into a discounted series\n",
-    "    w = list(w.fillna(0))\n",
-    "    xs = []\n",
+    "# def stock_weighted(x: pd.Series, w: pd.Series, decay:float = 0.8):\n",
+    "#     # xs is a stock of x inflow, weighted by w, with a decay of 0.8\n",
+    "#     x = list(x.fillna(0))\n",
+    "#     ws = stock_simple(w) # below this is the number of tokens for that country-month, which the stock_simple function turns into a discounted series\n",
+    "#     w = list(w.fillna(0))\n",
+    "#     xs = []\n",
     "    \n",
-    "    for n in range(len(x)):\n",
-    "        if n == 0: \n",
-    "            xs.append(x[n]) # stock starts in initial value\n",
-    "        else:\n",
-    "            num = w[n]*x[n] + decay * ws[n-1] * xs[n-1]\n",
+    "#     for n in range(len(x)):\n",
+    "#         if n == 0: \n",
+    "#             xs.append(x[n]) # stock starts in initial value\n",
+    "#         else:\n",
+    "#             num = w[n]*x[n] + decay * ws[n-1] * xs[n-1]\n",
     "            \n",
-    "            # word stock for topic = tokens * topic share + decay * past word stock for topic\n",
-    "            # past word stock for topic = total words stock * topic stock share\n",
+    "#             # word stock for topic = tokens * topic share + decay * past word stock for topic\n",
+    "#             # past word stock for topic = total words stock * topic stock share\n",
     "            \n",
-    "            if ws[n]>0:\n",
-    "                xs.append(num/ws[n])\n",
-    "            else:\n",
-    "                xs.append(num)\n",
-    "    return xs\n",
+    "#             if ws[n]>0:\n",
+    "#                 xs.append(num/ws[n])\n",
+    "#             else:\n",
+    "#                 xs.append(num)\n",
+    "#     return xs\n",
     "    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 177,
    "metadata": {},
    "outputs": [
     {
@@ -3204,16 +3623,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(55309, 81)\n",
+      "(55309, 82)\n",
       "(55309, 20)\n",
-      "(55309, 101)\n"
+      "(55309, 102)\n"
      ]
     },
     {
@@ -3222,7 +3641,7 @@
        "0"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 178,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3234,6 +3653,7 @@
     "unit_of_analyis = 'isocode'\n",
     "\n",
     "print(df_stocks.shape)\n",
+    "\n",
     "\n",
     "# generates missing values for some months, starting Decemeber 2018 (when using Jan 2018 as start date)\n",
     "# lcols = (df_feat.groupby(unit_of_analyis)\n",
@@ -3253,7 +3673,15 @@
     "print(new_df.shape)\n",
     "\n",
     "df_stocks.reset_index(drop=True, inplace=True)\n",
+    "\n",
+    "# sort by country and month to join accurately!\n",
+    "df_stocks.sort_values(by=[unit_of_analyis, 'month_year'], inplace=True)\n",
+    "\n",
     "df_stocks = df_stocks.join(new_df)\n",
+    "\n",
+    "# sort back to original order\n",
+    "df_stocks.sort_values(by=[unit_of_analyis, 'month_year'], inplace=True)\n",
+    "\n",
     "\n",
     "print(df_stocks.shape)\n",
     "\n",
@@ -3272,7 +3700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3282,7 +3710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 181,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3292,7 +3720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3302,7 +3730,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 183,
    "metadata": {},
    "outputs": [
     {
@@ -3421,7 +3849,7 @@
        "9     ABW  2000     12            1"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 183,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3436,7 +3864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 184,
    "metadata": {},
    "outputs": [
     {
@@ -3445,7 +3873,7 @@
        "0.0"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 184,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3462,7 +3890,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 185,
    "metadata": {},
    "outputs": [
     {
@@ -3495,7 +3923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3509,7 +3937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 187,
    "metadata": {},
    "outputs": [
     {
@@ -3799,7 +4227,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>10 rows × 103 columns</p>\n",
+       "<p>10 rows × 104 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -3863,10 +4291,10 @@
        "8              6.891271                   0.0           32                AF18  \n",
        "9              6.891271                   0.0           32                AF23  \n",
        "\n",
-       "[10 rows x 103 columns]"
+       "[10 rows x 104 columns]"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 187,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3877,7 +4305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 190,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3888,9 +4316,9 @@
     "\n",
     "    # Target encoding the regions that have at least 1 event of type 18, 19, or 20\n",
     "    region_encoder = ce.TargetEncoder(smoothing=1.0)\n",
-    "    region_encoder.fit(df_train['ActionGeo_ADM1Code'], df_train['deaths'])\n",
-    "    df_train['ActionGeo_ADM1Code'] = region_encoder.transform(df_train['ActionGeo_ADM1Code'], df_train['deaths'])\n",
-    "    df_test['ActionGeo_ADM1Code'] = region_encoder.transform(df_test['ActionGeo_ADM1Code'], df_test['deaths'])\n",
+    "    region_encoder.fit(df_train['ActionGeo_ADM1Code'], df_train[deaths_choice]) #['deaths'])\n",
+    "    df_train['ActionGeo_ADM1Code'] = region_encoder.transform(df_train['ActionGeo_ADM1Code'], df_train[deaths_choice]) #['deaths'])\n",
+    "    df_test['ActionGeo_ADM1Code'] = region_encoder.transform(df_test['ActionGeo_ADM1Code'], df_test[deaths_choice]) #['deaths'])\n",
     "    df = pd.concat([df_train, df_test])\n",
     "\n",
     "    # Getting the maximum, mean, and median regions for each month/year and country\n",
@@ -3905,25 +4333,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 191,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_14478/2258167720.py:9: SettingWithCopyWarning: \n",
+      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_35031/1906271164.py:9: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  df_train['ActionGeo_ADM1Code'] = region_encoder.transform(df_train['ActionGeo_ADM1Code'], df_train['deaths'])\n",
-      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_14478/2258167720.py:10: SettingWithCopyWarning: \n",
+      "  df_train['ActionGeo_ADM1Code'] = region_encoder.transform(df_train['ActionGeo_ADM1Code'], df_train[deaths_choice]) #['deaths'])\n",
+      "/var/folders/r9/gyc839012fz27dyc44xgpv9r0000gn/T/ipykernel_35031/1906271164.py:10: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  df_test['ActionGeo_ADM1Code'] = region_encoder.transform(df_test['ActionGeo_ADM1Code'], df_test['deaths'])\n"
+      "  df_test['ActionGeo_ADM1Code'] = region_encoder.transform(df_test['ActionGeo_ADM1Code'], df_test[deaths_choice]) #['deaths'])\n"
      ]
     }
    ],
@@ -3941,7 +4369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 192,
    "metadata": {},
    "outputs": [
     {
@@ -3960,7 +4388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 193,
    "metadata": {},
    "outputs": [
     {
@@ -3969,7 +4397,7 @@
        "0"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 193,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3990,14 +4418,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 194,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'deaths_all_intp_pop_pc', 'share_events_6', 'event_share_9_stock', 'event_share_8_stock', 'share_events_11_gov', 'share_events_9', 'share_events_8', 'share_events_12', 'Adm1_Mean', 'share_events_3', 'share_events_20', 'norm_total_events', 'share_events_10_opp', 'share_events_1_gov', 'share_events_7_opp', 'share_events_18', 'share_events_13_gov', 'share_state_deaths', 'share_events_4', 'share_events_15_gov', 'share_events_16_gov', 'event_share_19_stock', 'share_events_6_opp', 'share_events_16_opp', 'event_share_5_stock', 'share_events_5_gov', 'past12', 'share_events_16', 'past120', 'event_share_18_stock', 'event_share_10_stock', 'share_events_20_gov', 'event_share_14_stock', 'event_share_12_stock', 'share_events_9_opp', 'event_share_4_stock', 'share_events_7_gov', 'event_share_13_stock', 'share_events_18_gov', 'share_events_10', 'share_events_8_gov', 'share_events_6_gov', 'share_events_2_gov', 'share_events_18_opp', 'share_events_17_gov', 'share_events_3_gov', 'share_events_15_opp', 'event_share_20_stock', 'share_events_12_gov', 'share_events_19_opp', 'event_share_7_stock', 'past60', 'past6', 'share_events_7', 'share_events_14', 'share_events_13_opp', 'share_events_19', 'armedconf_intp_pop_since', 'share_events_11', 'share_events_10_gov', 'share_civilian_deaths', 'share_events_8_opp', 'armedconf_intp_pop', 'share_events_13', 'share_events_4_opp', 'share_events_2_opp', 'Adm1_Median', 'share_events_11_opp', 'num_regions', 'share_events_2', 'share_events_1', 'share_events_14_gov', 'event_share_3_stock', 'share_events_1_opp', 'share_events_5', 'event_share_6_stock', 'share_events_3_opp', 'share_events_17', 'event_share_15_stock', 'share_events_15', 'event_share_1_stock', 'share_events_9_gov', 'share_events_4_gov', 'share_onesided_deaths', 'Adm1_Max', 'share_events_5_opp', 'event_share_17_stock', 'event_share_16_stock', 'share_events_20_opp', 'share_nonstate_deaths', 'share_events_14_opp', 'share_events_12_opp', 'share_events_17_opp', 'event_share_11_stock', 'share_events_19_gov', 'event_share_2_stock'}\n"
+      "{'share_events_11_opp', 'share_events_9_opp', 'event_share_11_stock', 'share_events_13', 'share_events_17_opp', 'share_events_1_gov', 'past12', 'armedconf_intp_pop_since', 'share_events_7', 'share_events_6_gov', 'share_events_16_gov', 'share_events_5_opp', 'share_events_9', 'event_share_19_stock', 'share_events_17_gov', 'share_events_17', 'share_events_15', 'share_events_20_gov', 'share_events_20', 'event_share_12_stock', 'Adm1_Max', 'share_events_12_opp', 'share_events_19_opp', 'share_events_10', 'event_share_18_stock', 'Adm1_Mean', 'share_events_9_gov', 'event_share_2_stock', 'event_share_20_stock', 'event_share_7_stock', 'share_events_2_gov', 'past6', 'share_events_3', 'deaths_stock', 'share_onesided_deaths', 'event_share_17_stock', 'share_events_10_opp', 'event_share_16_stock', 'event_share_3_stock', 'share_events_18', 'share_civilian_deaths', 'share_events_12', 'event_share_1_stock', 'norm_total_events', 'event_share_6_stock', 'share_events_8_gov', 'share_events_7_opp', 'share_events_10_gov', 'share_events_2', 'share_events_4', 'share_events_14', 'Adm1_Median', 'share_events_15_gov', 'share_events_15_opp', 'event_share_5_stock', 'share_events_2_opp', 'share_state_deaths', 'share_events_14_opp', 'event_share_10_stock', 'share_events_18_gov', 'share_events_19', 'share_events_5', 'share_events_14_gov', 'event_share_13_stock', 'num_regions', 'share_events_11_gov', 'share_events_1_opp', 'share_events_18_opp', 'past120', 'share_events_16', 'share_events_4_opp', 'share_events_1', 'share_nonstate_deaths', 'share_events_13_gov', 'deaths_all_intp_pop_pc', 'share_events_12_gov', 'share_events_16_opp', 'share_events_8', 'event_share_15_stock', 'share_events_3_gov', 'event_share_14_stock', 'share_events_20_opp', 'event_share_9_stock', 'share_events_3_opp', 'event_share_8_stock', 'share_events_4_gov', 'share_events_8_opp', 'share_events_19_gov', 'share_events_5_gov', 'share_events_11', 'event_share_4_stock', 'past60', 'armedconf_intp_pop', 'share_events_7_gov', 'share_events_6', 'share_events_6_opp', 'share_events_13_opp'}\n"
      ]
     }
    ],
@@ -4016,7 +4444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 216,
    "metadata": {},
    "outputs": [
     {
@@ -4040,369 +4468,101 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>MonthYear</th>\n",
-       "      <th>isocode</th>\n",
-       "      <th>year</th>\n",
-       "      <th>country</th>\n",
-       "      <th>deaths</th>\n",
        "      <th>month_year</th>\n",
-       "      <th>Country Name</th>\n",
-       "      <th>intp_pop</th>\n",
-       "      <th>deaths_all_intp_pop_pc</th>\n",
-       "      <th>armedconf_intp_pop</th>\n",
-       "      <th>...</th>\n",
-       "      <th>num_regions</th>\n",
-       "      <th>Adm1_Max</th>\n",
-       "      <th>Adm1_Mean</th>\n",
-       "      <th>Adm1_Median</th>\n",
-       "      <th>share_state_deaths</th>\n",
-       "      <th>share_nonstate_deaths</th>\n",
-       "      <th>share_onesided_deaths</th>\n",
-       "      <th>share_civilian_deaths</th>\n",
        "      <th>month_sin</th>\n",
        "      <th>month_cos</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>AFG</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>Afghanistan</td>\n",
-       "      <td>54.0</td>\n",
+       "      <th>12129</th>\n",
        "      <td>2000-01-01</td>\n",
-       "      <td>Afghanistan</td>\n",
-       "      <td>19542982.0</td>\n",
-       "      <td>0.276314</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>32</td>\n",
-       "      <td>6.403298e+02</td>\n",
-       "      <td>6.029093e+02</td>\n",
-       "      <td>602.123846</td>\n",
-       "      <td>100.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>48.15</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>8.660254e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>AGO</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>Angola</td>\n",
-       "      <td>36.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Angola</td>\n",
-       "      <td>16394062.0</td>\n",
-       "      <td>0.219592</td>\n",
-       "      <td>True</td>\n",
-       "      <td>...</td>\n",
-       "      <td>20</td>\n",
-       "      <td>6.128571e+01</td>\n",
-       "      <td>2.868255e+01</td>\n",
-       "      <td>26.900901</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>100.0</td>\n",
-       "      <td>100.00</td>\n",
-       "      <td>0.5</td>\n",
+       "      <th>12141</th>\n",
+       "      <td>2000-02-01</td>\n",
        "      <td>0.866025</td>\n",
+       "      <td>5.000000e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>39</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ALB</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Albania</td>\n",
-       "      <td>3089027.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>14</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <th>12149</th>\n",
+       "      <td>2000-03-01</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>6.123234e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>51</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ARE</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>United Arab Emirates</td>\n",
-       "      <td>3275333.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>8</td>\n",
-       "      <td>1.298701e-02</td>\n",
-       "      <td>8.923573e-03</td>\n",
-       "      <td>0.009028</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
+       "      <th>12160</th>\n",
+       "      <td>2000-04-01</td>\n",
        "      <td>0.866025</td>\n",
+       "      <td>-5.000000e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>55</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ARG</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Argentina</td>\n",
-       "      <td>37070774.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>19</td>\n",
-       "      <td>2.648402e-10</td>\n",
-       "      <td>3.310646e-11</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <th>12171</th>\n",
+       "      <td>2000-05-01</td>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>-8.660254e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>555790</th>\n",
-       "      <td>1970-01-01 00:00:00.000202305</td>\n",
-       "      <td>XKX</td>\n",
-       "      <td>2023</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2023-05-01</td>\n",
-       "      <td>Kosovo</td>\n",
-       "      <td>1786038.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>10</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>-0.866025</td>\n",
+       "      <th>14014</th>\n",
+       "      <td>2023-01-01</td>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>8.660254e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>555793</th>\n",
-       "      <td>1970-01-01 00:00:00.000202305</td>\n",
-       "      <td>YEM</td>\n",
-       "      <td>2023</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2023-05-01</td>\n",
-       "      <td>Yemen, Rep.</td>\n",
-       "      <td>32981641.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>20</td>\n",
-       "      <td>2.178234e+02</td>\n",
-       "      <td>1.388658e+02</td>\n",
-       "      <td>134.351857</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>-0.866025</td>\n",
+       "      <th>14021</th>\n",
+       "      <td>2023-02-01</td>\n",
+       "      <td>0.866025</td>\n",
+       "      <td>5.000000e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>555807</th>\n",
-       "      <td>1970-01-01 00:00:00.000202305</td>\n",
-       "      <td>ZAF</td>\n",
-       "      <td>2023</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2023-05-01</td>\n",
-       "      <td>South Africa</td>\n",
-       "      <td>59392255.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>11</td>\n",
-       "      <td>3.418803e-02</td>\n",
-       "      <td>2.011180e-02</td>\n",
-       "      <td>0.018519</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>-0.866025</td>\n",
+       "      <th>14024</th>\n",
+       "      <td>2023-03-01</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>6.123234e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>555818</th>\n",
-       "      <td>1970-01-01 00:00:00.000202305</td>\n",
-       "      <td>ZMB</td>\n",
-       "      <td>2023</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2023-05-01</td>\n",
-       "      <td>Zambia</td>\n",
-       "      <td>19473125.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>11</td>\n",
-       "      <td>6.779661e-02</td>\n",
-       "      <td>4.572169e-02</td>\n",
-       "      <td>0.044444</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>-0.866025</td>\n",
+       "      <th>14032</th>\n",
+       "      <td>2023-04-01</td>\n",
+       "      <td>0.866025</td>\n",
+       "      <td>-5.000000e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>555825</th>\n",
-       "      <td>1970-01-01 00:00:00.000202305</td>\n",
-       "      <td>ZWE</td>\n",
-       "      <td>2023</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <th>14038</th>\n",
        "      <td>2023-05-01</td>\n",
-       "      <td>Zimbabwe</td>\n",
-       "      <td>15993524.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>12</td>\n",
-       "      <td>1.370968e+00</td>\n",
-       "      <td>1.130739e+00</td>\n",
-       "      <td>1.188818</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>-0.866025</td>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>-8.660254e-01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>55309 rows × 106 columns</p>\n",
+       "<p>281 rows × 3 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                           MonthYear isocode  year      country  deaths  \\\n",
-       "0      1970-01-01 00:00:00.000200001     AFG  2000  Afghanistan    54.0   \n",
-       "20     1970-01-01 00:00:00.000200001     AGO  2000       Angola    36.0   \n",
-       "39     1970-01-01 00:00:00.000200001     ALB  2000            0     0.0   \n",
-       "51     1970-01-01 00:00:00.000200001     ARE  2000            0     0.0   \n",
-       "55     1970-01-01 00:00:00.000200001     ARG  2000            0     0.0   \n",
-       "...                              ...     ...   ...          ...     ...   \n",
-       "555790 1970-01-01 00:00:00.000202305     XKX  2023            0     0.0   \n",
-       "555793 1970-01-01 00:00:00.000202305     YEM  2023            0     0.0   \n",
-       "555807 1970-01-01 00:00:00.000202305     ZAF  2023            0     0.0   \n",
-       "555818 1970-01-01 00:00:00.000202305     ZMB  2023            0     0.0   \n",
-       "555825 1970-01-01 00:00:00.000202305     ZWE  2023            0     0.0   \n",
+       "      month_year  month_sin     month_cos\n",
+       "12129 2000-01-01   0.500000  8.660254e-01\n",
+       "12141 2000-02-01   0.866025  5.000000e-01\n",
+       "12149 2000-03-01   1.000000  6.123234e-17\n",
+       "12160 2000-04-01   0.866025 -5.000000e-01\n",
+       "12171 2000-05-01   0.500000 -8.660254e-01\n",
+       "...          ...        ...           ...\n",
+       "14014 2023-01-01   0.500000  8.660254e-01\n",
+       "14021 2023-02-01   0.866025  5.000000e-01\n",
+       "14024 2023-03-01   1.000000  6.123234e-17\n",
+       "14032 2023-04-01   0.866025 -5.000000e-01\n",
+       "14038 2023-05-01   0.500000 -8.660254e-01\n",
        "\n",
-       "       month_year          Country Name    intp_pop  deaths_all_intp_pop_pc  \\\n",
-       "0      2000-01-01           Afghanistan  19542982.0                0.276314   \n",
-       "20     2000-01-01                Angola  16394062.0                0.219592   \n",
-       "39     2000-01-01               Albania   3089027.0                0.000000   \n",
-       "51     2000-01-01  United Arab Emirates   3275333.0                0.000000   \n",
-       "55     2000-01-01             Argentina  37070774.0                0.000000   \n",
-       "...           ...                   ...         ...                     ...   \n",
-       "555790 2023-05-01                Kosovo   1786038.0                0.000000   \n",
-       "555793 2023-05-01           Yemen, Rep.  32981641.0                0.000000   \n",
-       "555807 2023-05-01          South Africa  59392255.0                0.000000   \n",
-       "555818 2023-05-01                Zambia  19473125.0                0.000000   \n",
-       "555825 2023-05-01              Zimbabwe  15993524.0                0.000000   \n",
-       "\n",
-       "        armedconf_intp_pop  ...  num_regions      Adm1_Max     Adm1_Mean  \\\n",
-       "0                     True  ...           32  6.403298e+02  6.029093e+02   \n",
-       "20                    True  ...           20  6.128571e+01  2.868255e+01   \n",
-       "39                   False  ...           14  0.000000e+00  0.000000e+00   \n",
-       "51                   False  ...            8  1.298701e-02  8.923573e-03   \n",
-       "55                   False  ...           19  2.648402e-10  3.310646e-11   \n",
-       "...                    ...  ...          ...           ...           ...   \n",
-       "555790               False  ...           10  0.000000e+00  0.000000e+00   \n",
-       "555793               False  ...           20  2.178234e+02  1.388658e+02   \n",
-       "555807               False  ...           11  3.418803e-02  2.011180e-02   \n",
-       "555818               False  ...           11  6.779661e-02  4.572169e-02   \n",
-       "555825               False  ...           12  1.370968e+00  1.130739e+00   \n",
-       "\n",
-       "        Adm1_Median  share_state_deaths  share_nonstate_deaths  \\\n",
-       "0        602.123846               100.0                    0.0   \n",
-       "20        26.900901                 0.0                    0.0   \n",
-       "39         0.000000                 0.0                    0.0   \n",
-       "51         0.009028                 0.0                    0.0   \n",
-       "55         0.000000                 0.0                    0.0   \n",
-       "...             ...                 ...                    ...   \n",
-       "555790     0.000000                 0.0                    0.0   \n",
-       "555793   134.351857                 0.0                    0.0   \n",
-       "555807     0.018519                 0.0                    0.0   \n",
-       "555818     0.044444                 0.0                    0.0   \n",
-       "555825     1.188818                 0.0                    0.0   \n",
-       "\n",
-       "        share_onesided_deaths  share_civilian_deaths  month_sin  month_cos  \n",
-       "0                         0.0                  48.15        0.5   0.866025  \n",
-       "20                      100.0                 100.00        0.5   0.866025  \n",
-       "39                        0.0                   0.00        0.5   0.866025  \n",
-       "51                        0.0                   0.00        0.5   0.866025  \n",
-       "55                        0.0                   0.00        0.5   0.866025  \n",
-       "...                       ...                    ...        ...        ...  \n",
-       "555790                    0.0                   0.00        0.5  -0.866025  \n",
-       "555793                    0.0                   0.00        0.5  -0.866025  \n",
-       "555807                    0.0                   0.00        0.5  -0.866025  \n",
-       "555818                    0.0                   0.00        0.5  -0.866025  \n",
-       "555825                    0.0                   0.00        0.5  -0.866025  \n",
-       "\n",
-       "[55309 rows x 106 columns]"
+       "[281 rows x 3 columns]"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 216,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4410,9 +4570,10 @@
    "source": [
     "df_cyclical = df_deaths.copy()\n",
     "\n",
-    "encoder = CyclicalFeatures(variables=['month'], drop_original=True)\n",
+    "encoder = CyclicalFeatures(variables=['month'], drop_original=False)\n",
     "df_cyclical = encoder.fit_transform(df_cyclical)\n",
-    "df_cyclical"
+    "\n",
+    "df_cyclical.loc[df_cyclical['isocode'] == 'ALB', ['month_year', 'month_sin', 'month_cos']]"
    ]
   },
   {
@@ -4425,7 +4586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 214,
    "metadata": {},
    "outputs": [
     {
@@ -4434,7 +4595,8 @@
      "text": [
       "pop choice: intp_pop\n",
       "conflict choice: armedconf_intp_pop\n",
-      "deaths choice: deaths_all_intp_pop_pc\n"
+      "deaths choice: deaths_all_intp_pop_pc\n",
+      "2000-01-01 00:00:00 2023-03-01 00:00:00\n"
      ]
     },
     {
@@ -4460,6 +4622,7 @@
        "      <th></th>\n",
        "      <th>MonthYear</th>\n",
        "      <th>isocode</th>\n",
+       "      <th>month</th>\n",
        "      <th>year</th>\n",
        "      <th>deaths</th>\n",
        "      <th>month_year</th>\n",
@@ -4467,7 +4630,6 @@
        "      <th>deaths_all_intp_pop_pc</th>\n",
        "      <th>armedconf_intp_pop</th>\n",
        "      <th>past6</th>\n",
-       "      <th>past12</th>\n",
        "      <th>...</th>\n",
        "      <th>num_regions</th>\n",
        "      <th>Adm1_Max</th>\n",
@@ -4486,6 +4648,7 @@
        "      <th>0</th>\n",
        "      <td>1970-01-01 00:00:00.000200001</td>\n",
        "      <td>AFG</td>\n",
+       "      <td>1</td>\n",
        "      <td>2000</td>\n",
        "      <td>54.0</td>\n",
        "      <td>2000-01-01</td>\n",
@@ -4493,305 +4656,304 @@
        "      <td>0.276314</td>\n",
        "      <td>True</td>\n",
        "      <td>0.276314</td>\n",
-       "      <td>0.276314</td>\n",
        "      <td>...</td>\n",
        "      <td>32</td>\n",
-       "      <td>6.403298e+02</td>\n",
-       "      <td>6.029093e+02</td>\n",
-       "      <td>602.123846</td>\n",
-       "      <td>100.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>2.100745</td>\n",
+       "      <td>2.002104</td>\n",
+       "      <td>1.997804</td>\n",
+       "      <td>100.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "      <td>48.15</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <td>5.000000e-01</td>\n",
+       "      <td>8.660254e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>20</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>AGO</td>\n",
+       "      <td>1970-01-01 00:00:00.000200002</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>2</td>\n",
        "      <td>2000</td>\n",
-       "      <td>36.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Angola</td>\n",
-       "      <td>0.219592</td>\n",
+       "      <td>152.0</td>\n",
+       "      <td>2000-02-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>0.777290</td>\n",
        "      <td>True</td>\n",
-       "      <td>0.219592</td>\n",
-       "      <td>0.219592</td>\n",
+       "      <td>1.053604</td>\n",
        "      <td>...</td>\n",
-       "      <td>20</td>\n",
-       "      <td>6.128571e+01</td>\n",
-       "      <td>2.868255e+01</td>\n",
-       "      <td>26.900901</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>100.0</td>\n",
-       "      <td>100.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <td>33</td>\n",
+       "      <td>2.283090</td>\n",
+       "      <td>2.031706</td>\n",
+       "      <td>1.982797</td>\n",
+       "      <td>51.32</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>48.68</td>\n",
+       "      <td>71.05</td>\n",
+       "      <td>8.660254e-01</td>\n",
+       "      <td>5.000000e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>39</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ALB</td>\n",
+       "      <td>1970-01-01 00:00:00.000200003</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>3</td>\n",
        "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Albania</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>317.0</td>\n",
+       "      <td>2000-03-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>1.620053</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2.673657</td>\n",
        "      <td>...</td>\n",
-       "      <td>14</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <td>29</td>\n",
+       "      <td>2.283090</td>\n",
+       "      <td>2.013165</td>\n",
+       "      <td>2.000230</td>\n",
+       "      <td>84.23</td>\n",
+       "      <td>0.95</td>\n",
+       "      <td>14.83</td>\n",
+       "      <td>14.83</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>6.123234e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>51</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ARE</td>\n",
+       "      <th>59</th>\n",
+       "      <td>1970-01-01 00:00:00.000200004</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>4</td>\n",
        "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>United Arab Emirates</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>530.0</td>\n",
+       "      <td>2000-04-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>2.706927</td>\n",
+       "      <td>True</td>\n",
+       "      <td>5.380585</td>\n",
        "      <td>...</td>\n",
-       "      <td>8</td>\n",
-       "      <td>1.298701e-02</td>\n",
-       "      <td>8.923573e-03</td>\n",
-       "      <td>0.009028</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>31</td>\n",
+       "      <td>2.283090</td>\n",
+       "      <td>2.019678</td>\n",
+       "      <td>1.997804</td>\n",
+       "      <td>100.00</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>37.74</td>\n",
+       "      <td>8.660254e-01</td>\n",
+       "      <td>-5.000000e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>55</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ARG</td>\n",
+       "      <th>83</th>\n",
+       "      <td>1970-01-01 00:00:00.000200005</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>5</td>\n",
        "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Argentina</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>82.0</td>\n",
+       "      <td>2000-05-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>0.418548</td>\n",
+       "      <td>True</td>\n",
+       "      <td>5.799133</td>\n",
        "      <td>...</td>\n",
-       "      <td>19</td>\n",
-       "      <td>2.648402e-10</td>\n",
-       "      <td>3.310646e-11</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>32</td>\n",
+       "      <td>2.283090</td>\n",
+       "      <td>2.013083</td>\n",
+       "      <td>1.996960</td>\n",
+       "      <td>62.20</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <td>37.80</td>\n",
+       "      <td>43.90</td>\n",
+       "      <td>5.000000e-01</td>\n",
+       "      <td>-8.660254e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>63</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ARM</td>\n",
+       "      <th>106</th>\n",
+       "      <td>1970-01-01 00:00:00.000200006</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>6</td>\n",
        "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Armenia</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2.680412e-01</td>\n",
-       "      <td>2.033795e-01</td>\n",
-       "      <td>0.193939</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>68</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>ATG</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Antigua and Barbuda</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>69</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>AUS</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Australia</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>9</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>77</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>AUT</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Austria</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>...</td>\n",
-       "      <td>9</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>81</th>\n",
-       "      <td>1970-01-01 00:00:00.000200001</td>\n",
-       "      <td>AZE</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>Azerbaijan</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>2000-06-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>0.357076</td>\n",
+       "      <td>True</td>\n",
+       "      <td>6.156209</td>\n",
        "      <td>...</td>\n",
        "      <td>28</td>\n",
-       "      <td>5.183741e+01</td>\n",
-       "      <td>8.988681e+00</td>\n",
-       "      <td>0.407647</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>2.283090</td>\n",
+       "      <td>2.023741</td>\n",
+       "      <td>1.982797</td>\n",
+       "      <td>100.00</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.866025</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>10.00</td>\n",
+       "      <td>1.224647e-16</td>\n",
+       "      <td>-1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>121</th>\n",
+       "      <td>1970-01-01 00:00:00.000200007</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>7</td>\n",
+       "      <td>2000</td>\n",
+       "      <td>730.0</td>\n",
+       "      <td>2000-07-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>3.721488</td>\n",
+       "      <td>True</td>\n",
+       "      <td>9.877698</td>\n",
+       "      <td>...</td>\n",
+       "      <td>34</td>\n",
+       "      <td>2.283090</td>\n",
+       "      <td>2.050090</td>\n",
+       "      <td>2.025821</td>\n",
+       "      <td>100.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>22.19</td>\n",
+       "      <td>-5.000000e-01</td>\n",
+       "      <td>-8.660254e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>142</th>\n",
+       "      <td>1970-01-01 00:00:00.000200008</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>8</td>\n",
+       "      <td>2000</td>\n",
+       "      <td>1100.0</td>\n",
+       "      <td>2000-08-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>5.604255</td>\n",
+       "      <td>True</td>\n",
+       "      <td>15.205638</td>\n",
+       "      <td>...</td>\n",
+       "      <td>33</td>\n",
+       "      <td>2.268556</td>\n",
+       "      <td>2.018644</td>\n",
+       "      <td>1.999899</td>\n",
+       "      <td>100.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>1.45</td>\n",
+       "      <td>-8.660254e-01</td>\n",
+       "      <td>-5.000000e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>170</th>\n",
+       "      <td>1970-01-01 00:00:00.000200009</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>9</td>\n",
+       "      <td>2000</td>\n",
+       "      <td>1118.0</td>\n",
+       "      <td>2000-09-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>5.692441</td>\n",
+       "      <td>True</td>\n",
+       "      <td>20.120789</td>\n",
+       "      <td>...</td>\n",
+       "      <td>33</td>\n",
+       "      <td>2.268556</td>\n",
+       "      <td>2.015510</td>\n",
+       "      <td>1.997804</td>\n",
+       "      <td>100.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>1.16</td>\n",
+       "      <td>-1.000000e+00</td>\n",
+       "      <td>-1.836970e-16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>194</th>\n",
+       "      <td>1970-01-01 00:00:00.000200010</td>\n",
+       "      <td>AFG</td>\n",
+       "      <td>10</td>\n",
+       "      <td>2000</td>\n",
+       "      <td>224.0</td>\n",
+       "      <td>2000-10-01</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>1.139820</td>\n",
+       "      <td>True</td>\n",
+       "      <td>19.640556</td>\n",
+       "      <td>...</td>\n",
+       "      <td>32</td>\n",
+       "      <td>2.268556</td>\n",
+       "      <td>2.005108</td>\n",
+       "      <td>1.991962</td>\n",
+       "      <td>100.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>4.02</td>\n",
+       "      <td>-8.660254e-01</td>\n",
+       "      <td>5.000000e-01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>10 rows × 104 columns</p>\n",
+       "<p>10 rows × 106 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                       MonthYear isocode  year  deaths month_year  \\\n",
-       "0  1970-01-01 00:00:00.000200001     AFG  2000    54.0 2000-01-01   \n",
-       "20 1970-01-01 00:00:00.000200001     AGO  2000    36.0 2000-01-01   \n",
-       "39 1970-01-01 00:00:00.000200001     ALB  2000     0.0 2000-01-01   \n",
-       "51 1970-01-01 00:00:00.000200001     ARE  2000     0.0 2000-01-01   \n",
-       "55 1970-01-01 00:00:00.000200001     ARG  2000     0.0 2000-01-01   \n",
-       "63 1970-01-01 00:00:00.000200001     ARM  2000     0.0 2000-01-01   \n",
-       "68 1970-01-01 00:00:00.000200001     ATG  2000     0.0 2000-01-01   \n",
-       "69 1970-01-01 00:00:00.000200001     AUS  2000     0.0 2000-01-01   \n",
-       "77 1970-01-01 00:00:00.000200001     AUT  2000     0.0 2000-01-01   \n",
-       "81 1970-01-01 00:00:00.000200001     AZE  2000     0.0 2000-01-01   \n",
+       "                        MonthYear isocode  month  year  deaths month_year  \\\n",
+       "0   1970-01-01 00:00:00.000200001     AFG      1  2000    54.0 2000-01-01   \n",
+       "20  1970-01-01 00:00:00.000200002     AFG      2  2000   152.0 2000-02-01   \n",
+       "39  1970-01-01 00:00:00.000200003     AFG      3  2000   317.0 2000-03-01   \n",
+       "59  1970-01-01 00:00:00.000200004     AFG      4  2000   530.0 2000-04-01   \n",
+       "83  1970-01-01 00:00:00.000200005     AFG      5  2000    82.0 2000-05-01   \n",
+       "106 1970-01-01 00:00:00.000200006     AFG      6  2000    70.0 2000-06-01   \n",
+       "121 1970-01-01 00:00:00.000200007     AFG      7  2000   730.0 2000-07-01   \n",
+       "142 1970-01-01 00:00:00.000200008     AFG      8  2000  1100.0 2000-08-01   \n",
+       "170 1970-01-01 00:00:00.000200009     AFG      9  2000  1118.0 2000-09-01   \n",
+       "194 1970-01-01 00:00:00.000200010     AFG     10  2000   224.0 2000-10-01   \n",
        "\n",
-       "            Country Name  deaths_all_intp_pop_pc  armedconf_intp_pop  \\\n",
-       "0            Afghanistan                0.276314                True   \n",
-       "20                Angola                0.219592                True   \n",
-       "39               Albania                0.000000               False   \n",
-       "51  United Arab Emirates                0.000000               False   \n",
-       "55             Argentina                0.000000               False   \n",
-       "63               Armenia                0.000000               False   \n",
-       "68   Antigua and Barbuda                0.000000               False   \n",
-       "69             Australia                0.000000               False   \n",
-       "77               Austria                0.000000               False   \n",
-       "81            Azerbaijan                0.000000               False   \n",
+       "    Country Name  deaths_all_intp_pop_pc  armedconf_intp_pop      past6  ...  \\\n",
+       "0    Afghanistan                0.276314                True   0.276314  ...   \n",
+       "20   Afghanistan                0.777290                True   1.053604  ...   \n",
+       "39   Afghanistan                1.620053                True   2.673657  ...   \n",
+       "59   Afghanistan                2.706927                True   5.380585  ...   \n",
+       "83   Afghanistan                0.418548                True   5.799133  ...   \n",
+       "106  Afghanistan                0.357076                True   6.156209  ...   \n",
+       "121  Afghanistan                3.721488                True   9.877698  ...   \n",
+       "142  Afghanistan                5.604255                True  15.205638  ...   \n",
+       "170  Afghanistan                5.692441                True  20.120789  ...   \n",
+       "194  Afghanistan                1.139820                True  19.640556  ...   \n",
        "\n",
-       "       past6    past12  ...  num_regions      Adm1_Max     Adm1_Mean  \\\n",
-       "0   0.276314  0.276314  ...           32  6.403298e+02  6.029093e+02   \n",
-       "20  0.219592  0.219592  ...           20  6.128571e+01  2.868255e+01   \n",
-       "39  0.000000  0.000000  ...           14  0.000000e+00  0.000000e+00   \n",
-       "51  0.000000  0.000000  ...            8  1.298701e-02  8.923573e-03   \n",
-       "55  0.000000  0.000000  ...           19  2.648402e-10  3.310646e-11   \n",
-       "63  0.000000  0.000000  ...           11  2.680412e-01  2.033795e-01   \n",
-       "68  0.000000  0.000000  ...            1  0.000000e+00  0.000000e+00   \n",
-       "69  0.000000  0.000000  ...            9  0.000000e+00  0.000000e+00   \n",
-       "77  0.000000  0.000000  ...            9  0.000000e+00  0.000000e+00   \n",
-       "81  0.000000  0.000000  ...           28  5.183741e+01  8.988681e+00   \n",
+       "     num_regions  Adm1_Max  Adm1_Mean  Adm1_Median  share_state_deaths  \\\n",
+       "0             32  2.100745   2.002104     1.997804              100.00   \n",
+       "20            33  2.283090   2.031706     1.982797               51.32   \n",
+       "39            29  2.283090   2.013165     2.000230               84.23   \n",
+       "59            31  2.283090   2.019678     1.997804              100.00   \n",
+       "83            32  2.283090   2.013083     1.996960               62.20   \n",
+       "106           28  2.283090   2.023741     1.982797              100.00   \n",
+       "121           34  2.283090   2.050090     2.025821              100.00   \n",
+       "142           33  2.268556   2.018644     1.999899              100.00   \n",
+       "170           33  2.268556   2.015510     1.997804              100.00   \n",
+       "194           32  2.268556   2.005108     1.991962              100.00   \n",
        "\n",
-       "    Adm1_Median  share_state_deaths  share_nonstate_deaths  \\\n",
-       "0    602.123846               100.0                    0.0   \n",
-       "20    26.900901                 0.0                    0.0   \n",
-       "39     0.000000                 0.0                    0.0   \n",
-       "51     0.009028                 0.0                    0.0   \n",
-       "55     0.000000                 0.0                    0.0   \n",
-       "63     0.193939                 0.0                    0.0   \n",
-       "68     0.000000                 0.0                    0.0   \n",
-       "69     0.000000                 0.0                    0.0   \n",
-       "77     0.000000                 0.0                    0.0   \n",
-       "81     0.407647                 0.0                    0.0   \n",
+       "     share_nonstate_deaths  share_onesided_deaths  share_civilian_deaths  \\\n",
+       "0                     0.00                   0.00                  48.15   \n",
+       "20                    0.00                  48.68                  71.05   \n",
+       "39                    0.95                  14.83                  14.83   \n",
+       "59                    0.00                   0.00                  37.74   \n",
+       "83                    0.00                  37.80                  43.90   \n",
+       "106                   0.00                   0.00                  10.00   \n",
+       "121                   0.00                   0.00                  22.19   \n",
+       "142                   0.00                   0.00                   1.45   \n",
+       "170                   0.00                   0.00                   1.16   \n",
+       "194                   0.00                   0.00                   4.02   \n",
        "\n",
-       "    share_onesided_deaths  share_civilian_deaths  month_sin  month_cos  \n",
-       "0                     0.0                  48.15        0.5   0.866025  \n",
-       "20                  100.0                 100.00        0.5   0.866025  \n",
-       "39                    0.0                   0.00        0.5   0.866025  \n",
-       "51                    0.0                   0.00        0.5   0.866025  \n",
-       "55                    0.0                   0.00        0.5   0.866025  \n",
-       "63                    0.0                   0.00        0.5   0.866025  \n",
-       "68                    0.0                   0.00        0.5   0.866025  \n",
-       "69                    0.0                   0.00        0.5   0.866025  \n",
-       "77                    0.0                   0.00        0.5   0.866025  \n",
-       "81                    0.0                   0.00        0.5   0.866025  \n",
+       "        month_sin     month_cos  \n",
+       "0    5.000000e-01  8.660254e-01  \n",
+       "20   8.660254e-01  5.000000e-01  \n",
+       "39   1.000000e+00  6.123234e-17  \n",
+       "59   8.660254e-01 -5.000000e-01  \n",
+       "83   5.000000e-01 -8.660254e-01  \n",
+       "106  1.224647e-16 -1.000000e+00  \n",
+       "121 -5.000000e-01 -8.660254e-01  \n",
+       "142 -8.660254e-01 -5.000000e-01  \n",
+       "170 -1.000000e+00 -1.836970e-16  \n",
+       "194 -8.660254e-01  5.000000e-01  \n",
        "\n",
-       "[10 rows x 104 columns]"
+       "[10 rows x 106 columns]"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 214,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4806,154 +4968,21 @@
     "\n",
     "df.drop(columns=['country', pop_choice], inplace=True)\n",
     "\n",
+    "# Only keep any years before 2023 and within 2023, only keep months that are not April or May\n",
+    "df = df[(df['year'] != 2023) | ((df['year'] == 2023) & (~df['month'].isin([4, 5])))]\n",
+    "\n",
+    "\n",
+    "print(df.month_year.min(), df.month_year.max())\n",
     "df.head(10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 218,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>month_year</th>\n",
-       "      <th>month_sin</th>\n",
-       "      <th>month_cos</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>294</th>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>5.000000e-01</td>\n",
-       "      <td>8.660254e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1670</th>\n",
-       "      <td>2000-02-01</td>\n",
-       "      <td>8.660254e-01</td>\n",
-       "      <td>5.000000e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3019</th>\n",
-       "      <td>2000-03-01</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>6.123234e-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4342</th>\n",
-       "      <td>2000-04-01</td>\n",
-       "      <td>8.660254e-01</td>\n",
-       "      <td>-5.000000e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5657</th>\n",
-       "      <td>2000-05-01</td>\n",
-       "      <td>5.000000e-01</td>\n",
-       "      <td>-8.660254e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6973</th>\n",
-       "      <td>2000-06-01</td>\n",
-       "      <td>1.224647e-16</td>\n",
-       "      <td>-1.000000e+00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8330</th>\n",
-       "      <td>2000-07-01</td>\n",
-       "      <td>-5.000000e-01</td>\n",
-       "      <td>-8.660254e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9675</th>\n",
-       "      <td>2000-08-01</td>\n",
-       "      <td>-8.660254e-01</td>\n",
-       "      <td>-5.000000e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11009</th>\n",
-       "      <td>2000-09-01</td>\n",
-       "      <td>-1.000000e+00</td>\n",
-       "      <td>-1.836970e-16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12328</th>\n",
-       "      <td>2000-10-01</td>\n",
-       "      <td>-8.660254e-01</td>\n",
-       "      <td>5.000000e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13693</th>\n",
-       "      <td>2000-11-01</td>\n",
-       "      <td>-5.000000e-01</td>\n",
-       "      <td>8.660254e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15037</th>\n",
-       "      <td>2000-12-01</td>\n",
-       "      <td>-2.449294e-16</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16387</th>\n",
-       "      <td>2001-01-01</td>\n",
-       "      <td>5.000000e-01</td>\n",
-       "      <td>8.660254e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17782</th>\n",
-       "      <td>2001-02-01</td>\n",
-       "      <td>8.660254e-01</td>\n",
-       "      <td>5.000000e-01</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      month_year     month_sin     month_cos\n",
-       "294   2000-01-01  5.000000e-01  8.660254e-01\n",
-       "1670  2000-02-01  8.660254e-01  5.000000e-01\n",
-       "3019  2000-03-01  1.000000e+00  6.123234e-17\n",
-       "4342  2000-04-01  8.660254e-01 -5.000000e-01\n",
-       "5657  2000-05-01  5.000000e-01 -8.660254e-01\n",
-       "6973  2000-06-01  1.224647e-16 -1.000000e+00\n",
-       "8330  2000-07-01 -5.000000e-01 -8.660254e-01\n",
-       "9675  2000-08-01 -8.660254e-01 -5.000000e-01\n",
-       "11009 2000-09-01 -1.000000e+00 -1.836970e-16\n",
-       "12328 2000-10-01 -8.660254e-01  5.000000e-01\n",
-       "13693 2000-11-01 -5.000000e-01  8.660254e-01\n",
-       "15037 2000-12-01 -2.449294e-16  1.000000e+00\n",
-       "16387 2001-01-01  5.000000e-01  8.660254e-01\n",
-       "17782 2001-02-01  8.660254e-01  5.000000e-01"
-      ]
-     },
-     "execution_count": 110,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "df.loc[df['isocode'] == 'DEU', ['month_year', 'month_sin', 'month_cos']].head(14)"
+    "df.rename(columns={deaths_choice: 'deaths_all_pc', conflict_choice: 'armedconf'}, inplace=True)"
    ]
   },
   {


### PR DESCRIPTION
- death_stock (alongside past deaths)
- deaths_pc used for Admin1
- kept all stock for now as had been re-joining them wrong! (though of only keeping stocks of event 19)
- share of gov and opp events (0-100 for _gov and 0-50 for _opp)
- rename special deaths & conflict to deaths_pc and armedconf
- drop post March 2023